### PR TITLE
Test download by expected data hash instead of successful image decode.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "TransferPublisher",
     platforms: [
-     // .macOS(.v10_15),
+      .macOS(.v10_15),
       .iOS(.v13)
     ],
     products: [

--- a/Tests/TransferPublisherTests/TransferPublisherTests.swift
+++ b/Tests/TransferPublisherTests/TransferPublisherTests.swift
@@ -1,13 +1,16 @@
 import XCTest
 @testable import TransferPublisher
 import Combine
-#if os(iOS)  // TODO: Just need to include AppKit for the macOS test
-import UIKit
+import CryptoKit
 
 
 final class TransferPublisherTests: XCTestCase {
   
   var cancellables = Set<AnyCancellable>()
+  
+  let remoteFile: (url: URL, bytes: Int, sha256: String) = (URL(string: "https://upload.wikimedia.org/wikipedia/commons/8/89/Wilkin_River_close_to_its_confluence_with_Makarora_River%2C_Otago%2C_New_Zealand.jpg")!,
+                                                            20880207,
+                                                            "d26366ce096a061fadcf7c95dbf82fc76aa19f52cfcbf51c3b67c5eac5518f9a")
   
   // Just a simple test to download and see progress in console
   func testDownload() {
@@ -15,7 +18,7 @@ final class TransferPublisherTests: XCTestCase {
     let waiter = XCTWaiter()
     let networkResponded = XCTestExpectation()
     
-    let request = URLRequest(url: URL(string: "https://upload.wikimedia.org/wikipedia/commons/8/89/Wilkin_River_close_to_its_confluence_with_Makarora_River%2C_Otago%2C_New_Zealand.jpg")!)
+    let request = URLRequest(url: remoteFile.url)
     
     URLSession(configuration: .default).downloadTaskPublisher(with: request)
       .sink(receiveCompletion: { (completion) in
@@ -25,10 +28,13 @@ final class TransferPublisherTests: XCTestCase {
         print(output)
         if case .complete(let data) = output {
           print("Received file: \(data.count)")
-          let image = UIImage(data: data)
-          print(image.debugDescription)
-          XCTAssert(data.isEmpty == false)
-          XCTAssert(image != nil)
+          XCTAssert(data.isEmpty == false, "no download data")
+          XCTAssert(data.count == self.remoteFile.bytes, "byte count mismatch")
+          var hash = CryptoKit.SHA256()
+          hash.update(data: data)
+          let digestString = hash.finalize().map({String(format: "%02hhx", $0)}).joined()
+          print("hash: \(digestString)")
+          XCTAssert(digestString == self.remoteFile.sha256, "download data hash mismatch")
         }
     }.store(in: &cancellables)
     
@@ -38,4 +44,3 @@ final class TransferPublisherTests: XCTestCase {
   
 }
 
-#endif


### PR DESCRIPTION
set min macOS version; update test to use download hash